### PR TITLE
bootstrap: add sqlite3 package

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -11,6 +11,8 @@ bootstrap__consul_certs_client_key: '{{lookup("bitwarden", "consul/certs",      
 bootstrap__sshguard_whitelist_extra: ['{{lookup("bitwarden", "sshguard/whitelist", field="jakubgs-home")}}']
 # Wireguard
 wireguard_consul_acl_token: '{{lookup("bitwarden", "consul/acl-tokens", field="wireguard")}}'
+# System packages
+bootstrap__extra_packages: ['sqlite3']
 
 # Custom SSH accounts for Nimbus fleet, should start from UID 8000.
 bootstrap__active_extra_users:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -31,7 +31,7 @@
 
 - name: go-waku
   src: git@github.com:status-im/infra-role-go-waku.git
-  version: 6c0d00933a1d6ca59e54f9cf85ec603a7a15b149
+  version: c3b522a94d7a8e7c9d62b2ff4c9058cffbf87f5b
   scm: git
 
 - name: waku-peers


### PR DESCRIPTION
Adds sqlite3 package to maintain sqlite dbs.

Also fixes 2 minor issues:
- creating `ansible/files/.gitkeep` file
- fixing missing `infra-role-go-waku` commit